### PR TITLE
Use ConfigManager and routing_table

### DIFF
--- a/define/channel.www_server.js
+++ b/define/channel.www_server.js
@@ -178,7 +178,13 @@ www_server.route = function(){
     }
 }
 
-www_server.unmanaged_route = www_server.route.bind(www_server.server);
+www_server.unmanaged_route = function (route) {
+    try {
+        www_server.server.route(arguments[0]);
+    } catch(err) {
+        www_server.routing_table.push(arguments[0]);
+    }
+};
 
 
 www_server.static_route = function(path, url) {        


### PR DESCRIPTION
User can now set listen port from 'index.js'. I had to add array 'routing_table' to store routings created on requiring this module, so they would be added later, after connection's created. Availability of connection is tested in try-catch blocks, because some external modules, like channel-rest, are started after www-server uses 'routing_table', so their routings must be added directly to server.
