### PR TITLE
Add HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## How to use configure `sealious-www-server`?
-WWW-server configuration allows you to open ports for listening, definin
+WWW-server configuration allows you to open ports for listening, define
 protocols served on those ports and redirections(useful when you want to
 force users to use HTTPS by redirecting them from HTTP). Configuration is
 separated into 2 sections: `connections` and `redirections`.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ As described in HapiJS docs, passing `tls` object in config causes connection to
 You can take a look at example of how to do it in [hello-world](https://github.com/Rayvenden/hello-world/tree/https_example).
 
 ### How `redirections` section works?
-It's also an array for sub-sections which are being later iterated by
-`www_server.start()`. Every sub-section should be an object containing following properties:
+It's also an array of sub-sections. They contain information about redirections
+on ports. Every sub-section should be an object containing following properties:
 * `protocol`
 * source redirection port(`from`)
 * destination redirection port(`to`)
 
-`www_server.start()` reads this sub-sections and tells server how to handle
+Sealious reads this sub-sections and tells server how to handle
 connection on each port by calling [server.ext()](http://hapijs.com/api#serverextevent-method-options) from HapiJS.
 
 ### How to test HTTPS?

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+## How to use configure `sealious-www-server`?
+WWW-server configuration allows you to open ports for listening, definin
+protocols served on those ports and redirections(useful when you want to
+force users to use HTTPS by redirecting them from HTTP). Configuration is
+separated into 2 sections: `connections` and `redirections`.
+
+### How `connections` section works?
+It's just an array with all connections configurations. All sub-sections should
+be objects with properties prepared to be passed directly to [server.connection()](http://hapijs.com/api#serverconnectionoptions) method from HapiJS.
+As described in HapiJS docs, passing `tls` object in config causes connection to use TLS/SSL.
+You can take a look at example of how to do it in [hello-world](https://github.com/Rayvenden/hello-world/tree/https_example).
+
+### How `redirections` section works?
+It's also an array for sub-sections which are being later iterated by
+`www_server.start()`. Every sub-section should be an object containing following properties:
+* `protocol`
+* source redirection port(`from`)
+* destination redirection port(`to`)
+
+`www_server.start()` reads this sub-sections and tells server how to handle
+connection on each port by calling [server.ext()](http://hapijs.com/api#serverextevent-method-options) from HapiJS.
+
+### How to test HTTPS?
+After getting [hello-world](https://github.com/Rayvenden/hello-world/tree/https_example) and [www_server](https://github.com/Sealious/sealious-www-server/tree/trello%23https_support) and launching it(`sudo` isn't needed) following links should get you to HTTPS version of service on 4430 port(HTTP 2 HTTPS redirection is enabled in example):
+* https://localhost:4430/
+* http://localhost:8080/
+
+Your browser will warn you about insecure certificate, because it's self-signed.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,30 @@ separated into 2 sections: `connections` and `redirections`.
 
 ### How `connections` section works?
 It's just an array with all connections configurations. All sub-sections should
-be objects with properties prepared to be passed directly to [server.connection()](http://hapijs.com/api#serverconnectionoptions) method from HapiJS.
+be objects with properties prepared to be passed directly to
+[server.connection()](http://hapijs.com/api#serverconnectionoptions) method from HapiJS.
 As described in HapiJS docs, passing `tls` object in config causes connection to use TLS/SSL.
-You can take a look at example of how to do it in [hello-world](https://github.com/Rayvenden/hello-world/tree/https_example).
+
+Example:
+```
+Sealious.ConfigManager.set_config(
+    "chip.channel.www_server", {
+        connections: [
+            { // HTTPS section
+                port: 4430,
+                tls: {
+                    key: fs.readFileSync("sealious.key"),
+                    cert: fs.readFileSync("sealious.crt")
+                }
+            },
+            { // HTTP section
+                port: 8080
+            }
+    }
+);
+```
+Code above opens 2 connections. First for HTTPS on port 4430 with SSL certificate
+and key in `tls` object. Second for plain HTTP on port 8080.
 
 ### How `redirections` section works?
 It's also an array of sub-sections. They contain information about redirections
@@ -18,10 +39,44 @@ on ports. Every sub-section should be an object containing following properties:
 * destination redirection port(`to`)
 
 Sealious reads this sub-sections and tells server how to handle
-connection on each port by calling [server.ext()](http://hapijs.com/api#serverextevent-method-options) from HapiJS.
+connection on each port by calling 
+[server.ext()](http://hapijs.com/api#serverextevent-method-options) from HapiJS.
+
+Example:
+```
+Sealious.ConfigManager.set_config(
+    "chip.channel.www_server", {
+        connections: [
+            { // HTTPS section
+                port: 4430,
+                tls: {
+                    key: fs.readFileSync("sealious.key"),
+                    cert: fs.readFileSync("sealious.crt")
+                }
+            },
+            { // HTTP section
+                port: 8080,
+            }
+        ],
+        redirections: [{ // HTTP 2 HTTPS redirection
+            from: 8080,
+            to: 4430,
+            protocol: "https"
+        }]
+    }
+);
+```
+Code above opens 2 connections like example before, but also force
+redirection from port 8080 to 4430. We specify protocol as
+HTTPS, so browser will be redirected and try to use TLS/SSL with HTTP.
 
 ### How to test HTTPS?
-After getting [hello-world](https://github.com/Rayvenden/hello-world/tree/https_example) and [www_server](https://github.com/Sealious/sealious-www-server/tree/trello%23https_support) and launching it(`sudo` isn't needed) following links should get you to HTTPS version of service on 4430 port(HTTP 2 HTTPS redirection is enabled in example):
+After getting complete configuration example from
+[hello-world](https://github.com/Rayvenden/hello-world/tree/https_example)
+and
+[www_server](https://github.com/Sealious/sealious-www-server/tree/trello%23https_support)
+and launching it(`sudo` isn't needed) following links should get you to HTTPS version
+of service on 4430 port(HTTP 2 HTTPS redirection is enabled in example):
 * https://localhost:4430/
 * http://localhost:8080/
 

--- a/define/channel.www_server.js
+++ b/define/channel.www_server.js
@@ -13,7 +13,10 @@ var www_server = new Sealious.ChipTypes.Channel("www_server");
 
 Sealious.ConfigManager.set_default_config(
     "chip.channel.www_server", {
-        port: 8080
+        connection: {
+            port: 8080,
+            routes: { cors: true }
+        }
     }
 );
 
@@ -30,8 +33,8 @@ function add_route(route) {
 }
 
 www_server.start = function(){
-    var port = Sealious.ConfigManager.get_config().chip.channel.www_server.port;
-    this.server.connection({port: port,  routes: { cors: true }});
+    var port = Sealious.ConfigManager.get_config().chip.channel.www_server.connection.port;
+    this.server.connection(Sealious.ConfigManager.get_config().chip.channel.www_server.connection);
     for (i in this.routing_table) {
         this.server.route(this.routing_table[i]);
     }

--- a/define/channel.www_server.js
+++ b/define/channel.www_server.js
@@ -14,13 +14,10 @@ var www_server = new Sealious.ChipTypes.Channel("www_server");
 
 Sealious.ConfigManager.set_default_config(
     "chip.channel.www_server", {
-        connections: {
-            http: {
-                port: 8080,
-                routes: { cors: true }
-            }
-        },
-        redirections: {}
+        connections: [{
+            port: 8080,
+            routes: { cors: true }
+        }]
     }
 );
 

--- a/define/channel.www_server.js
+++ b/define/channel.www_server.js
@@ -1,3 +1,4 @@
+var url = require("url");
 var Sealious = require("sealious");
 var sha1 = require("sha1");
 
@@ -13,10 +14,13 @@ var www_server = new Sealious.ChipTypes.Channel("www_server");
 
 Sealious.ConfigManager.set_default_config(
     "chip.channel.www_server", {
-        connection: {
-            port: 8080,
-            routes: { cors: true }
-        }
+        connections: {
+            http: {
+                port: 8080,
+                routes: { cors: true }
+            }
+        },
+        redirections: {}
     }
 );
 
@@ -33,23 +37,43 @@ function add_route(route) {
 }
 
 www_server.start = function(){
-    var port = Sealious.ConfigManager.get_config().chip.channel.www_server.connection.port;
-    this.server.connection(Sealious.ConfigManager.get_config().chip.channel.www_server.connection);
+    var config = Sealious.ConfigManager.get_config().chip.channel.www_server;
+    for (var cnx in config.connections) {
+        this.server.connection(config.connections[cnx]);
+    }
+    for (var rdir in config.redirections) {
+        this.server.ext("onRequest", function (request, reply) {
+            if (request.connection.info.port === config.redirections[rdir].from) {
+                return reply.redirect(url.format({
+                    protocol: config.redirections[rdir].protocol,
+                    hostname: request.info.hostname,
+                    pathname: request.url.path,
+                    port: config.redirections[rdir].to
+                }));
+            }
+            reply.continue();
+        });
+    }
     for (i in this.routing_table) {
         this.server.route(this.routing_table[i]);
     }
-	process.on('uncaughtException', function(err) {
-		if(err.errno === 'EADDRINUSE')
-			console.log("Port " + port + " is already taken - cannot start www-server.");
-		else if(err.errno === 'EACCES')
-			console.log("Unsufficient privileges to start listening on port " + port + ".");
-		else 
-			console.error(err);
-		process.exit(1);
-	});  
 	www_server.server.start(function(err){
-		Sealious.Logger.info('SERVER RUNNING: '+www_server.server.info.uri+"\n");
-	})
+        if (err) {
+            Sealious.Logger.error(err.message);
+            process.exit(1);
+        } else {
+            for (var cnx in config.connections) {
+                Sealious.Logger.info(
+                    "SERVER RUNNING: " +
+                    (typeof config.connections[cnx].tls === "undefined" ? "http" : "https") +
+                    "://" +
+                    www_server.server.info.host +
+                    ":" +
+                    config.connections[cnx].port
+                );
+            }
+	    }
+    });
 }
 
 www_server.get_context = function(request){


### PR DESCRIPTION
Now configuration has separate section for connection specific settings. I plan to add HTTP 2 HTTPS redirection specific settings, so having things separated may become handy, because this way we will be able to pass all connection's settings in one object from config to HapiJS's server.connection() method. It adds some boilerplate, so I would like to read your opinion on this.
